### PR TITLE
feat: resolve dependencies relative to config.root

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "vite": "*"
   },
   "dependencies": {
-    "esbuild": "^0.8.31"
+    "esbuild": "^0.8.31",
+    "resolve-from": "^5.0.0"
   },
   "devDependencies": {
     "@mdx-js/mdx": "^2.0.0-next.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,13 @@ export default createPlugin
 function createPlugin(mdxOptions?: mdx.Options): Plugin {
   return {
     name: 'vite-plugin-mdx',
-    configResolved({ plugins }) {
-      const reactRefresh = plugins.find((p) => p.name === 'react-refresh')
-
-      this.transform = async function (code_mdx, id, ssr) {
+    configResolved(config) {
+      const reactRefresh = config.plugins.find(
+        (p) => p.name === 'react-refresh'
+      )
+      this.transform = async function (code, id, ssr) {
         if (/\.mdx?$/.test(id)) {
-          const code = await transform({ code_mdx, mdxOptions, ssr })
+          code = await transform(code, mdxOptions, ssr, config.root)
           const refreshResult = await reactRefresh?.transform!.call(
             this,
             code,

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,30 +1,23 @@
 import { startService, Service } from 'esbuild'
 import mdx from '@mdx-js/mdx'
 import { join as pathJoin } from 'path'
+import resolve = require('resolve-from')
 
 export { transform }
 export { stopService }
 
 const pluginName = 'vite-plugin-mdx'
 
-async function transform({
-  code_mdx,
-  mdxOptions,
-  ssr = false
-}: {
-  code_mdx: string
-  mdxOptions?: mdx.Options
-  ssr?: boolean
-}): Promise<string> {
-  const code_jsx = await mdxToJsx(code_mdx, mdxOptions)
-  const code_es2019 = await jsxToES2019(code_jsx)
-  const code_final = injectImports(code_es2019, ssr)
-  return code_final
-}
-
-async function mdxToJsx(code_mdx: string, mdxOptions?: mdx.Options) {
+async function transform(
+  code_mdx: string,
+  mdxOptions?: mdx.Options,
+  ssr = false,
+  root = __dirname
+) {
   const code_jsx = await mdx(code_mdx, mdxOptions)
-  return code_jsx
+  const code_es2019 = await jsxToES2019(code_jsx)
+  const code_final = injectImports(code_es2019, ssr, root)
+  return code_final
 }
 
 async function jsxToES2019(code_jsx: string) {
@@ -56,20 +49,20 @@ async function jsxToES2019(code_jsx: string) {
   return code_es2019
 }
 
-function injectImports(code_es2019: string, ssr: boolean) {
-  if (isInstalled('preact')) {
+function injectImports(code_es2019: string, ssr: boolean, root: string) {
+  if (resolve.silent(root, 'preact')) {
     return [
       `import { h } from 'preact'`,
-      `import { mdx } from '${getMdxImportPath('@mdx-js/preact', ssr)}'`,
+      `import { mdx } from '${getMdxImportPath('@mdx-js/preact', ssr, root)}'`,
       '',
       code_es2019
     ].join('\n')
   }
 
-  if (isInstalled('react')) {
+  if (resolve.silent(root, 'react')) {
     return [
       `import React from 'react'`,
-      `import { mdx } from '${getMdxImportPath('@mdx-js/react', ssr)}'`,
+      `import { mdx } from '${getMdxImportPath('@mdx-js/react', ssr, root)}'`,
       '',
       code_es2019
     ].join('\n')
@@ -79,35 +72,24 @@ function injectImports(code_es2019: string, ssr: boolean) {
     `[Wrong Usage][${pluginName}] You need to \`npm install react\` or \`npm install preact\`.`
   )
 }
-function getMdxImportPath(mdxPackageName: string, ssr: boolean): string {
-  if (!isInstalled(mdxPackageName)) {
-    throw new Error(
-      `[Wrong Usage][${pluginName}] You need to \`npm install ${mdxPackageName}\`.`
-    )
-  }
-  if (!ssr) {
-    return mdxPackageName
-  } else {
-    return resolveEsmEntry(mdxPackageName)
-  }
-}
 
-function resolveEsmEntry(moduleName: string): string {
-  const packageJson = require(pathJoin(moduleName, 'package.json'))
-  const { module: esmPath } = packageJson
-  const esmEntry = require.resolve(pathJoin(moduleName, esmPath))
-  return esmEntry
-}
-
-function isInstalled(packageName: string): boolean {
-  let yes
-  try {
-    require(packageName)
-    yes = true
-  } catch (err) {
-    yes = false
+function getMdxImportPath(
+  mdxPackageName: string,
+  ssr: boolean,
+  root: string
+): string {
+  const packageJsonPath = resolve.silent(
+    root,
+    pathJoin(mdxPackageName, 'package.json')
+  )
+  if (packageJsonPath) {
+    return ssr
+      ? pathJoin(mdxPackageName, require(packageJsonPath).module)
+      : mdxPackageName
   }
-  return yes
+  throw new Error(
+    `[Wrong Usage][${pluginName}] You need to \`npm install ${mdxPackageName}\`.`
+  )
 }
 
 let _service: Promise<Service> | undefined

--- a/yarn.lock
+++ b/yarn.lock
@@ -859,6 +859,11 @@ repeat-string@^1.0.0, repeat-string@^1.5.4:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
+resolve-from@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
+  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
 resolve@^1.19.0, resolve@^1.3.2:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"


### PR DESCRIPTION
When using a local clone of this plugin, it can fail to resolve `react` and `@mdx-js/react`, so this PR uses `config.root` (from Vite config) when resolving those packages.