### PR TITLE
feat: let other plugins manipulate mdxOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/es-module-lexer": "^0.3.0",
     "@types/node": "^14.14.22",
     "typescript": "^4.1.3",
+    "unified": "^9.2.1",
     "vite": "^2.0.4"
   },
   "description": "Vite plugin for MDX",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,24 @@
-import { Plugin } from 'vite'
+import { Plugin as VitePlugin } from 'vite'
 import mdx from '@mdx-js/mdx'
+import type { Plugin as UnifiedPlugin } from 'unified'
 import { stopService, transform } from './transform'
 
 export default createPlugin
 
-function createPlugin(mdxOptions?: mdx.Options): Plugin {
+export interface MdxPlugin extends VitePlugin {
+  mdxOptions: mdx.Options & {
+    remarkPlugins: UnifiedPlugin[]
+    rehypePlugins: UnifiedPlugin[]
+  }
+}
+
+function createPlugin(mdxOptions: mdx.Options = {}): MdxPlugin {
+  mdxOptions.remarkPlugins ??= []
+  mdxOptions.rehypePlugins ??= []
+
   return {
     name: 'vite-plugin-mdx',
+    mdxOptions: mdxOptions as any,
     configResolved({ plugins }) {
       const reactRefresh = plugins.find((p) => p.name === 'react-refresh')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -984,6 +984,18 @@ unified@9.0.0:
     trough "^1.0.0"
     vfile "^4.0.0"
 
+unified@^9.2.1:
+  version "9.2.1"
+  resolved "https://registry.npmjs.org/unified/-/unified-9.2.1.tgz#ae18d5674c114021bfdbdf73865ca60f410215a3"
+  integrity sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-buffer "^2.0.0"
+    is-plain-obj "^2.0.0"
+    trough "^1.0.0"
+    vfile "^4.0.0"
+
 unist-builder@2.0.3, unist-builder@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-builder/-/unist-builder-2.0.3.tgz#77648711b5d86af0942f334397a33c5e91516436"


### PR DESCRIPTION
- extend the `vite.Plugin` interface as `MdxPlugin` which has a `mdxOptions` property
- ensure the `remarkPlugins` and `rehypePlugins` options are defined, so Vite plugins can search/mutate them easier

This feature is used by https://github.com/vitejs/vite-plugin-react-pages/pull/16 to inject `remark-frontmatter` when it's missing.

https://github.com/aleclarson/vite-plugin-react-pages/blob/d06307d90ea57e260e32e0093b7d50740ca8a043/packages/react-pages/src/node/index.ts#L63-L75