### PR TITLE
fix: package resolution with local vite clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "vite": "*"
   },
   "dependencies": {
-    "esbuild": "^0.8.31"
+    "esbuild": "^0.8.31",
+    "find-dependency": "^1.3.0"
   },
   "devDependencies": {
     "@mdx-js/mdx": "^2.0.0-next.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -450,6 +450,11 @@ extend@^3.0.0:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
+find-dependency@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/find-dependency/-/find-dependency-1.3.0.tgz#36e1d47e6978772c6e3e9145d2d3f8b65b2b0718"
+  integrity sha512-3/jC4BIM4WvzO1b5m2QC1KPudgqcpTGGOA9lKMhQ9RUhGEvtS5oUGU2JlFWhhuFUK1I4MhrL66amf0qxkxhoIQ==
+
 fsevents@~2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"


### PR DESCRIPTION
Both `require.resolve` and `resolve-from` use the `Module._resolveLookupPaths` function, which searches the node_modules of the entry module (vite/bin/vite.js) when a package is not found in the node_modules of a given root. This leads to false positives when a local clone of vite is used, since vite has preact in its devDependencies.

Even if a local clone of vite is not being used, the global node_modules are searched, which can also lead to false positives if you have preact or @mdx-js/react installed globally for some odd reason.

To solve these issues, I've installed `find-dependency`, a small package I wrote back in 2017, which imitates Node's resolution algorithm without the entry node_modules fallback and (optionally) without the global node_modules fallback.

Here's the [source code](https://github.com/aleclarson/find-dependency/blob/master/findDependency.js) of `find-dependency`.