### PR TITLE
fix: ssr hack not necessary anymore

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,14 +23,13 @@ function createPlugin(mdxOptions: mdx.Options = {}): MdxPlugin {
       const reactRefresh = config.plugins.find(
         (p) => p.name === 'react-refresh'
       )
-      this.transform = async function (code, id, ssr) {
+      this.transform = async function (code, id) {
         if (/\.mdx?$/.test(id)) {
-          code = await transform(code, mdxOptions, ssr, config.root)
+          code = await transform(code, mdxOptions, config.root)
           const refreshResult = await reactRefresh?.transform!.call(
             this,
             code,
-            id + '.js',
-            ssr
+            id + '.js'
           )
           return refreshResult || code
         }


### PR DESCRIPTION
It seems like Vite now rightfully always treats dependencies as
externals. Using the ES module export is therefore actually erroneous,
e.g. #13.