### PR TITLE
fix(types): allow plugin tuples and presets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,9 @@
-import { Plugin as VitePlugin } from 'vite'
-import mdx from '@mdx-js/mdx'
-import type { Plugin as UnifiedPlugin } from 'unified'
 import { stopService, transform } from './transform'
+import { MdxOptions, MdxPlugin } from './types'
 
 export default createPlugin
 
-export interface MdxPlugin extends VitePlugin {
-  mdxOptions: mdx.Options & {
-    remarkPlugins: UnifiedPlugin[]
-    rehypePlugins: UnifiedPlugin[]
-  }
-}
-
-function createPlugin(mdxOptions: mdx.Options = {}): MdxPlugin {
+function createPlugin(mdxOptions: MdxOptions = {}): MdxPlugin {
   mdxOptions.remarkPlugins ??= []
   mdxOptions.rehypePlugins ??= []
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,6 +1,7 @@
 import { startService, Service } from 'esbuild'
 import mdx from '@mdx-js/mdx'
 import findDependency from 'find-dependency'
+import { MdxOptions } from './types'
 
 export { transform }
 export { stopService }
@@ -9,10 +10,10 @@ const pluginName = 'vite-plugin-mdx'
 
 async function transform(
   code_mdx: string,
-  mdxOptions?: mdx.Options,
+  mdxOptions?: MdxOptions,
   root = __dirname
 ) {
-  const code_jsx = await mdx(code_mdx, mdxOptions)
+  const code_jsx = await mdx(code_mdx, mdxOptions as any)
   const code_es2019 = await jsxToES2019(code_jsx)
   const code_final = injectImports(code_es2019, root)
   return code_final

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,8 +7,8 @@ type RehypePlugin = Pluggable
 
 export interface MdxOptions
   extends Omit<mdx.Options, 'remarkPlugins' | 'rehypePlugins'> {
-  remarkPlugins?: RemarkPlugin[]
-  rehypePlugins?: RehypePlugin[]
+  remarkPlugins?: Readonly<RemarkPlugin>[]
+  rehypePlugins?: Readonly<RehypePlugin>[]
 }
 
 export interface MdxPlugin extends VitePlugin {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,20 @@
+import type { Plugin as VitePlugin } from 'vite'
+import type { Pluggable } from 'unified'
+import mdx from '@mdx-js/mdx'
+
+type RemarkPlugin = Pluggable
+type RehypePlugin = Pluggable
+
+export interface MdxOptions
+  extends Omit<mdx.Options, 'remarkPlugins' | 'rehypePlugins'> {
+  remarkPlugins?: RemarkPlugin[]
+  rehypePlugins?: RehypePlugin[]
+}
+
+export interface MdxPlugin extends VitePlugin {
+  mdxOptions: MdxOptions & {
+    // Plugin arrays always exist when accessed by Vite plugin.
+    remarkPlugins: RemarkPlugin[]
+    rehypePlugins: RehypePlugin[]
+  }
+}


### PR DESCRIPTION
- Allow for [Unified presets](https://github.com/unifiedjs/unified/blob/0f3b92833fd910c21edef423ad5891af7f11a82e/types/ts4.0/index.d.ts#L234-L243)
- Allow for [Unified plugin tuples](https://github.com/unifiedjs/unified/blob/0f3b92833fd910c21edef423ad5891af7f11a82e/types/ts4.0/index.d.ts#L254-L263)
	```ts
	mdx({
		remarkPlugins: [
			[plugin, { foo: true }],
		]
	})
	```