### PR TITLE
feat: accept a function for file-specific options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,3 +93,19 @@ Features:
 
 - [React example](/examples/react/).
 - [Preact example](/examples/preact/).
+
+## File-specific options
+
+To define options a per-file basis, you can pass a function to the `mdx` plugin factory.
+
+```ts
+mdx((filename) => {
+  // Any options passed to `mdx` can be returned.
+  return {
+    remarkPlugins: [
+      // Enable a plugin based on the current file.
+      /\/components\//.test(filename) && someRemarkPlugin,
+    ]
+  }
+})
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,19 +3,30 @@ import { MdxOptions, MdxPlugin } from './types'
 
 export default createPlugin
 
-function createPlugin(mdxOptions: MdxOptions = {}): MdxPlugin {
-  mdxOptions.remarkPlugins ??= []
-  mdxOptions.rehypePlugins ??= []
+function createPlugin(
+  mdxOptions: MdxOptions | ((filename: string) => MdxOptions) = {}
+): MdxPlugin {
+  let getMdxOptions: ((filename: string) => MdxOptions) | undefined
+  let globalMdxOptions: any = mdxOptions
+  if (typeof mdxOptions === 'function') {
+    getMdxOptions = mdxOptions
+    globalMdxOptions = {}
+  }
+
+  // Ensure plugin arrays exist for other Vite plugins to manipulate.
+  globalMdxOptions.remarkPlugins ??= []
+  globalMdxOptions.rehypePlugins ??= []
 
   return {
     name: 'vite-plugin-mdx',
-    mdxOptions: mdxOptions as any,
+    mdxOptions: globalMdxOptions,
     configResolved(config) {
       const reactRefresh = config.plugins.find(
         (p) => p.name === 'react-refresh'
       )
       this.transform = async function (code, id, ssr) {
         if (/\.mdx?$/.test(id)) {
+          const mdxOptions = mergeOptions(globalMdxOptions, getMdxOptions?.(id))
           code = await transform(code, mdxOptions, config.root)
           const refreshResult = await reactRefresh?.transform!.call(
             this,
@@ -30,5 +41,24 @@ function createPlugin(mdxOptions: MdxOptions = {}): MdxPlugin {
     async closeBundle() {
       await stopService()
     }
+  }
+}
+
+function mergeOptions(globalOptions: MdxOptions, localOptions?: MdxOptions) {
+  if (!localOptions) {
+    return globalOptions
+  }
+  return {
+    ...globalOptions,
+    ...localOptions,
+    remarkPlugins: globalOptions.remarkPlugins!.concat(
+      localOptions.remarkPlugins || []
+    ),
+    rehypePlugins: globalOptions.rehypePlugins!.concat(
+      localOptions.rehypePlugins || []
+    ),
+    compilers: (globalOptions.compilers || []).concat(
+      localOptions.compilers || []
+    )
   }
 }


### PR DESCRIPTION
For applying plugins conditionally based on filename.
```ts
mdx(filename => {
	return {
		remarkPlugins: filename.endsWith('foo.mdx') ? [myPlugin] : []
	}
})
```