### PR TITLE
feat: let plugins be false

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,20 +45,24 @@ function createPlugin(
 }
 
 function mergeOptions(globalOptions: MdxOptions, localOptions?: MdxOptions) {
-  if (!localOptions) {
-    return globalOptions
-  }
   return {
     ...globalOptions,
     ...localOptions,
-    remarkPlugins: globalOptions.remarkPlugins!.concat(
-      localOptions.remarkPlugins || []
+    remarkPlugins: mergeArrays(
+      globalOptions.remarkPlugins,
+      localOptions?.remarkPlugins
     ),
-    rehypePlugins: globalOptions.rehypePlugins!.concat(
-      localOptions.rehypePlugins || []
+    rehypePlugins: mergeArrays(
+      globalOptions.rehypePlugins,
+      localOptions?.rehypePlugins
     ),
-    compilers: (globalOptions.compilers || []).concat(
-      localOptions.compilers || []
+    compilers: mergeArrays(
+      globalOptions.compilers, //
+      localOptions?.compilers
     )
   }
+}
+
+function mergeArrays<T>(a: T[] = [], b: T[] = []) {
+  return a.concat(b).filter(Boolean)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,8 @@ import type { Plugin as VitePlugin } from 'vite'
 import type { Pluggable } from 'unified'
 import mdx from '@mdx-js/mdx'
 
-type RemarkPlugin = Pluggable
-type RehypePlugin = Pluggable
+type RemarkPlugin = Pluggable | false
+type RehypePlugin = Pluggable | false
 
 export interface MdxOptions
   extends Omit<mdx.Options, 'remarkPlugins' | 'rehypePlugins'> {


### PR DESCRIPTION
Useful in combination with #16, so you can disable a specific plugin based on filename without repeating shared plugins in a separate array or doing awkward array merging by hand.

**Before:**
```ts
mdx(filename => {
	return {
		remarkPlugins: [
			...(test(filename) ? [myPlugin] : []),
			sharedPlugin,
		]
	}
})
```

**After:**
```ts
mdx(filename => {
	return {
		remarkPlugins: [
			test(filename) && myPlugin,
			sharedPlugin,
		]
	}
})
```