### PR TITLE
fix: remove `compilers` merging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,10 +55,6 @@ function mergeOptions(globalOptions: MdxOptions, localOptions?: MdxOptions) {
     rehypePlugins: mergeArrays(
       globalOptions.rehypePlugins,
       localOptions?.rehypePlugins
-    ),
-    compilers: mergeArrays(
-      globalOptions.compilers, //
-      localOptions?.compilers
     )
   }
 }


### PR DESCRIPTION
This option is no longer exposed since @mdx-js/mdx@2.0.0-next.9

See https://github.com/mdx-js/mdx/commit/62931c2c81872734a7af6749b46cf0ec6a5f50fe\#diff-963c3f3dc78a5437cf9e3ef52c7dbf9cff408d7c0295441f596b19e98b3040c0