### PR TITLE
feat: add `withImports` higher-order plugin

### DIFF
--- a/src/imports.ts
+++ b/src/imports.ts
@@ -52,3 +52,13 @@ export function resolveImport(
 export function assertImportExists(name: string, cwd: string) {
   return resolveImport(name, cwd, true) && name
 }
+
+export type NamedImports = {
+  [packageName: string]: string | string[]
+}
+
+export function inferNamedImports(root: string): NamedImports {
+  return resolveImport('preact', root)
+    ? { preact: ['h'], '@mdx-js/preact': ['mdx'] }
+    : { react: 'React', '@mdx-js/react': ['mdx'] }
+}

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,20 +1,28 @@
 import { startService, Service } from 'esbuild'
 import { MdxOptions } from './types'
-import { assertImportExists, requireMdx, resolveImport } from './resolveImport'
+import { assertImportExists, inferNamedImports, requireMdx } from './imports'
 
-export { transform }
 export { stopService }
 
-async function transform(
-  code_mdx: string,
-  mdxOptions?: MdxOptions,
-  root = __dirname
+export function createTransformer(
+  root: string,
+  namedImports = inferNamedImports(root)
 ) {
   const mdx = requireMdx(root)
-  const code_jsx = await mdx(code_mdx, mdxOptions as any)
-  const code_es2019 = await jsxToES2019(code_jsx)
-  const code_final = injectImports(code_es2019, root)
-  return code_final
+  const imports = Object.entries(namedImports).map(
+    ([packageName, imported]) => {
+      assertImportExists(packageName, root)
+      return Array.isArray(imported)
+        ? `import { ${imported.join(', ')} } from '${packageName}'`
+        : `import ${imported} from '${packageName}'`
+    }
+  )
+
+  return async function transform(code_mdx: string, mdxOptions?: MdxOptions) {
+    const code_jsx = await mdx(code_mdx, mdxOptions as any)
+    const code_es2019 = await jsxToES2019(code_jsx)
+    return imports.concat('', code_es2019).join('\n')
+  }
 }
 
 async function jsxToES2019(code_jsx: string) {
@@ -44,28 +52,6 @@ async function jsxToES2019(code_jsx: string) {
   )
 
   return code_es2019
-}
-
-function injectImports(code_es2019: string, root: string) {
-  if (resolveImport('preact', root)) {
-    return [
-      `import { h } from 'preact'`,
-      `import { mdx } from '${assertImportExists('@mdx-js/preact', root)}'`,
-      '',
-      code_es2019
-    ].join('\n')
-  }
-
-  if (resolveImport('react', root)) {
-    return [
-      `import React from 'react'`,
-      `import { mdx } from '${assertImportExists('@mdx-js/react', root)}'`,
-      '',
-      code_es2019
-    ].join('\n')
-  }
-
-  throw new Error(`[vite-plugin-mdx] "react" or "preact" must be installed`)
 }
 
 let _service: Promise<Service> | undefined

--- a/src/viteMdxTransclusion/createMdxAstCompiler.ts
+++ b/src/viteMdxTransclusion/createMdxAstCompiler.ts
@@ -1,4 +1,4 @@
-import { requireFrom, resolveMdxImport } from '../resolveImport'
+import { requireFrom, resolveMdxImport } from '../imports'
 import { RemarkPlugin } from '../types'
 
 /**


### PR DESCRIPTION
This lets other frameworks inject their own imports.

```ts
import mdx from "vite-plugin-mdx"

export default mdx.withImports({
  react: "React", // default import
  "@mdx-js/react": ["mdx"], // named imports
})
```

Then users can install a wrapper package for a framework that is not supported by default.

    npm install @svelte/vite-plugin-mdx