### PR TITLE
Document how to use MDX v2 with Vite

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,11 @@
 ====================== [**WE ARE LOOKING FOR A NEW MAINTAINER**](https://github.com/brillout/vite-plugin-mdx/issues/42) ====================
- 
+
 # Vite Plugin MDX
 
-Vite plugin to use MDX with your Vite app.
+Vite plugin to use MDX v1 with your Vite app. For MDX v2 use [`@mdx-js/rollup`](https://www.npmjs.com/package/@mdx-js/rollup) instead, [this comment](https://github.com/brillout/vite-plugin-mdx/issues/44#issuecomment-974540152) explains how to implement it.
 
 Features:
 
-- Works with MDX v1 and MDX v2.
 - Works with React and Preact.
 - Works with Vue [**[WIP]**](https://github.com/brillout/vite-plugin-mdx/issues/3).
 - HMR support.


### PR DESCRIPTION
Initially I was going to migrate this plugin to ESM, but then I learned about `mdx-js/rollup`, and it appears to work great, HMR, SSR, everything, so I just edited the readme to redirect people who're using MDX v2 to `@mdx-js/rollup` instead.

I wasn't sure what to do with the message that you're looking for a new maintainer, so I left it, but I think people will quickly upgrade to MDX v2 once it's stable, so there shouldn't be much need to maintain this plugin anymore soon.

Let me know if this need any more changes.

Resolves #44
