### PR TITLE
Define supported versions of Vite and MDX

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "dist"
   ],
   "peerDependencies": {
-    "@mdx-js/mdx": "*",
-    "vite": "*"
+    "@mdx-js/mdx": "<2",
+    "vite": "<3"
   },
   "dependencies": {
     "@alloc/quick-lru": "^5.2.0",

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 # Vite Plugin MDX
 
-Vite plugin to use MDX v1 with your Vite app. For MDX v2 use [`@mdx-js/rollup`](https://www.npmjs.com/package/@mdx-js/rollup) instead, [this comment](https://github.com/brillout/vite-plugin-mdx/issues/44#issuecomment-974540152) explains how to implement it.
+Use this Vite plugin to use MDX v1 with your Vite v2 app. For Vite v3+ we recommend migrating to MDX v2 using the official [`@mdx-js/rollup`](https://www.npmjs.com/package/@mdx-js/rollup), [this comment](https://github.com/brillout/vite-plugin-mdx/issues/44#issuecomment-974540152) explains how to implement it.
 
 Features:
 

--- a/readme.md
+++ b/readme.md
@@ -24,10 +24,6 @@ Features:
       ```sh
       npm install @mdx-js/mdx
       ```
-      Or MDX v2:
-      ```sh
-      npm install @mdx-js/mdx@next
-      ```
    3. MDX React:
       ```sh
       npm install @mdx-js/react


### PR DESCRIPTION
I think it would be best to define supported versions of Vite and MDX through `peerDependencies`, which should result in warnings or errors about version mismatches during installing dependencies when people try to use this plugin with the wrong version. Vite v3+ and MDX v2 are using ESM, so this CJS plugin won't work for those.

I also recommend deprecating this package, to push people to migrate to MDX v2 and newer versions of Vite.

Related: #54